### PR TITLE
fix: handle error in label-transform when using empty data (#3096)

### DIFF
--- a/packages/vega-label/src/Label.js
+++ b/packages/vega-label/src/Label.js
@@ -86,13 +86,13 @@ inherits(Label, Transform, {
 
     // run label layout
     labelLayout(
-      pulse.materialize(pulse.SOURCE).source,
+      pulse.materialize(pulse.SOURCE).source || [],
       _.size,
       _.sort,
-      array(_.offset || 1),
+      array(_.offset == null ? 1 : _.offset),
       array(_.anchor || Anchors),
       _.avoidMarks || [],
-      _.avoidBaseMark === false ? false : true,
+      _.avoidBaseMark !== false,
       _.lineAnchor || 'end',
       _.markIndex || 0,
       _.padding || 0,


### PR DESCRIPTION
* fix: handle empty data

* Update packages/vega-label/src/Label.js

Co-authored-by: Dominik Moritz <domoritz@gmail.com>

* dont use nullish coalescing operator and cleanup

* Update packages/vega-label/src/Label.js

Co-authored-by: Dominik Moritz <domoritz@gmail.com>

Co-authored-by: Dominik Moritz <domoritz@gmail.com>